### PR TITLE
Implemented model controller 

### DIFF
--- a/src/servers/Web/Daas.Api/Controllers/UserController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/UserController.cs
@@ -28,4 +28,11 @@ public class UsersController : ControllerBase
        var dummies = _mediator.Send(new GetDummyQuery());
        return dummies;
     }
+     [Route("/payload")]
+    [HttpPost]
+    public Task<ResultModel[]> payload([FromBody] RequestModel[]  sus)
+    {
+        var result = _mediator.Send(new GetPayloadQuery(sus));
+        return result;
+    }
 }

--- a/src/servers/Web/Daas.Api/Controllers/UserController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/UserController.cs
@@ -3,6 +3,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Daas.Domain.Entities;
 using Daas.Application.DTO.RequestDTO;
+using System.Collections;
 namespace Daas.API.Controllers;
 
 [ApiController]
@@ -29,9 +30,9 @@ public class UsersController : ControllerBase
        var dummies = _mediator.Send(new GetDummyQuery());
        return dummies;
     }
-     [Route("/payload")]
+    [Route("/DummyData")]
     [HttpPost]
-    public Task<ResultModel[]> payload([FromBody] RequestModel[]  sus)
+    public Task<ArrayList> DummyDataGenerator([FromBody] RequestModel[]  sus)
     {
         var result = _mediator.Send(new GetPayloadQuery(sus));
         return result;

--- a/src/servers/Web/Daas.Api/Controllers/UserController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/UserController.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Daas.Domain.Entities;
+using Daas.Application.DTO.RequestDTO;
 namespace Daas.API.Controllers;
 
 [ApiController]

--- a/src/servers/Web/Daas.Api/Controllers/UserController.cs
+++ b/src/servers/Web/Daas.Api/Controllers/UserController.cs
@@ -30,11 +30,11 @@ public class UsersController : ControllerBase
        var dummies = _mediator.Send(new GetDummyQuery());
        return dummies;
     }
-    [Route("/DummyData")]
+    [Route("/DummyData/{howmany}")]
     [HttpPost]
-    public Task<ArrayList> DummyDataGenerator([FromBody] RequestModel[]  sus)
+    public Task<ArrayList> DummyDataGenerator([FromBody] RequestModel[] sus, [FromRoute]int howmany)
     {
-        var result = _mediator.Send(new GetPayloadQuery(sus));
+        var result = _mediator.Send(new GetPayloadQuery(sus,howmany));
         return result;
     }
 }

--- a/src/servers/Web/Daas.Application/DTO/RequestDTO/RequestModel.cs
+++ b/src/servers/Web/Daas.Application/DTO/RequestDTO/RequestModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Daas.Application.DTO.RequestDTO;
+
+public class RequestModel
+{
+    public string fieldType { get; set; } 
+    public string fieldValue { get; set; }
+}

--- a/src/servers/Web/Daas.Application/DTO/RequestDTO/RequestModel.cs
+++ b/src/servers/Web/Daas.Application/DTO/RequestDTO/RequestModel.cs
@@ -2,6 +2,6 @@
 
 public class RequestModel
 {
-    public string fieldName { get; set; } 
-    public string fieldType { get; set; }
+    public required string  fieldName { get; set; } 
+    public required string fieldType { get; set; }
 }

--- a/src/servers/Web/Daas.Application/DTO/RequestDTO/RequestModel.cs
+++ b/src/servers/Web/Daas.Application/DTO/RequestDTO/RequestModel.cs
@@ -2,6 +2,6 @@
 
 public class RequestModel
 {
-    public string fieldType { get; set; } 
-    public string fieldValue { get; set; }
+    public string fieldName { get; set; } 
+    public string fieldType { get; set; }
 }

--- a/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQuery.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQuery.cs
@@ -1,0 +1,8 @@
+﻿using MediatR;
+using Daas.Domain.Entities;
+using Daas.Application.DTO.RequestDTO;
+namespace Daas.Application.Users.Queries;
+
+
+public record GetPayloadQuery( RequestModel[]  sus ):IRequest<ResultModel[]>;
+ 

--- a/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQuery.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQuery.cs
@@ -1,8 +1,9 @@
 ﻿using MediatR;
 using Daas.Domain.Entities;
 using Daas.Application.DTO.RequestDTO;
+using System.Collections;
 namespace Daas.Application.Users.Queries;
 
 
-public record GetPayloadQuery( RequestModel[]  sus ):IRequest<ResultModel[]>;
+public record GetPayloadQuery( RequestModel[]  sus ):IRequest<ArrayList>;
  

--- a/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQuery.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQuery.cs
@@ -5,5 +5,5 @@ using System.Collections;
 namespace Daas.Application.Users.Queries;
 
 
-public record GetPayloadQuery( RequestModel[]  sus ):IRequest<ArrayList>;
+public record GetPayloadQuery( RequestModel[]  sus,int howmany ):IRequest<ArrayList>;
  

--- a/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQueryHandlers.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQueryHandlers.cs
@@ -1,5 +1,4 @@
 ﻿using Daas.Domain.Entities;
-using Daas.Domain.Entities;
 using MediatR;
 using MediatR.NotificationPublishers;
 using Microsoft.VisualBasic.FileIO;
@@ -17,7 +16,7 @@ public class GetPayloadQueryHandlers : IRequestHandler<GetPayloadQuery, ArrayLis
 
         //ResultModel data = new ResultModel();
         ArrayList data = new ArrayList();
-        int iterations = 3;
+        int iterations = request.howmany;
         string s;
         string answer;
         while (iterations>0)

--- a/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQueryHandlers.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQueryHandlers.cs
@@ -1,0 +1,40 @@
+﻿using Daas.Domain.Entities;
+
+using MediatR;
+using Daas.Domain.Entities;
+using Microsoft.VisualBasic.FileIO;
+
+namespace Daas.Application.Users.Queries;
+
+public class GetPayloadQueryHandlers : IRequestHandler<GetPayloadQuery, ResultModel[]>
+{
+    public Task<ResultModel[]> Handle(GetPayloadQuery request, CancellationToken cancellationToken)
+    {
+        var one="";
+        var two="";
+        var three="";
+        var four="";
+
+            one = request.sus[0].fieldType;
+            two = request.sus[0].fieldValue;
+            three = request.sus[1].fieldType;
+            four = request.sus[1].fieldValue;
+        
+
+
+        ResultModel[] P=new ResultModel[3];
+        P[0] = new ResultModel();
+        P[1] = new ResultModel();
+        P[2] = new ResultModel();
+        P[0].columnValue = "1";
+        P[1].columnValue = "2";
+        P[2].columnValue = "3";
+        P[0].fieldValue = "Akash";
+        P[1].fieldValue = "Krishna";
+        P[2].fieldValue = "Mohan";
+        
+        
+        return Task.FromResult(P);
+
+    }
+}

--- a/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQueryHandlers.cs
+++ b/src/servers/Web/Daas.Application/Users/Queries/GetPayloadQueryHandlers.cs
@@ -1,40 +1,71 @@
 ﻿using Daas.Domain.Entities;
-
-using MediatR;
 using Daas.Domain.Entities;
+using MediatR;
+using MediatR.NotificationPublishers;
 using Microsoft.VisualBasic.FileIO;
+using System.Collections;
+using System.Dynamic;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Daas.Application.Users.Queries;
 
-public class GetPayloadQueryHandlers : IRequestHandler<GetPayloadQuery, ResultModel[]>
+public class GetPayloadQueryHandlers : IRequestHandler<GetPayloadQuery, ArrayList>
 {
-    public Task<ResultModel[]> Handle(GetPayloadQuery request, CancellationToken cancellationToken)
+    public Task<ArrayList> Handle(GetPayloadQuery request, CancellationToken cancellationToken)
     {
-        var one="";
-        var two="";
-        var three="";
-        var four="";
+        Dictionary<string, string> x = new Dictionary<string, string>();
 
-            one = request.sus[0].fieldType;
-            two = request.sus[0].fieldValue;
-            three = request.sus[1].fieldType;
-            four = request.sus[1].fieldValue;
+        //ResultModel data = new ResultModel();
+        ArrayList data = new ArrayList();
+        int iterations = 3;
+        string s;
+        string answer;
+        while (iterations>0)
+        {
+            var row = new ExpandoObject() as IDictionary<string, object>;
+            for (int i = 0; i < request.sus.Length; i++)
+            {
+
+                s = request.sus[i].fieldType.ToLower();
+                if (s == "int")
+                {
+                    Random rand = new Random();
+                    answer = rand.Next(1, 13).ToString();
+                    x.Add(request.sus[i].fieldName, answer);
+                    row.Add(request.sus[i].fieldName, answer);
+                }
+            }
+            data.Add(row);
+            iterations--;
+            x.Clear();
+        }
+        return Task.FromResult(data);
+
+        //var one="";
+        //var two="";
+        //var three="";
+        //var four="";
+
+        //    one = request.sus[0].fieldType;
+        //    two = request.sus[0].fieldValue;
+        //    three = request.sus[1].fieldType;
+        //    four = request.sus[1].fieldValue;
         
 
 
-        ResultModel[] P=new ResultModel[3];
-        P[0] = new ResultModel();
-        P[1] = new ResultModel();
-        P[2] = new ResultModel();
-        P[0].columnValue = "1";
-        P[1].columnValue = "2";
-        P[2].columnValue = "3";
-        P[0].fieldValue = "Akash";
-        P[1].fieldValue = "Krishna";
-        P[2].fieldValue = "Mohan";
+        //ResultModel[] P=new ResultModel[3];
+        //P[0] = new ResultModel();
+        //P[1] = new ResultModel();
+        //P[2] = new ResultModel();
+        //P[0].columnValue = "1";
+        //P[1].columnValue = "2";
+        //P[2].columnValue = "3";
+        //P[0].fieldValue = "Akash";
+        //P[1].fieldValue = "Krishna";
+        //P[2].fieldValue = "Mohan";
         
         
-        return Task.FromResult(P);
+        //return Task.FromResult(P);
 
     }
 }

--- a/src/servers/Web/Daas.Domain/ResultModel.cs
+++ b/src/servers/Web/Daas.Domain/ResultModel.cs
@@ -4,7 +4,7 @@ namespace Daas.Domain.Entities;
 
 public class ResultModel
 {
-    public ArrayList data;
+    public ArrayList ?data;
     //public string fieldName  { get; set; }
     //public string fieldValue { get; set; }
     

--- a/src/servers/Web/Daas.Domain/ResultModel.cs
+++ b/src/servers/Web/Daas.Domain/ResultModel.cs
@@ -1,0 +1,9 @@
+﻿namespace Daas.Domain.Entities;
+
+public class ResultModel
+{
+
+    public string columnValue  { get; set; }
+    public string fieldValue { get; set; }
+    
+}

--- a/src/servers/Web/Daas.Domain/ResultModel.cs
+++ b/src/servers/Web/Daas.Domain/ResultModel.cs
@@ -1,9 +1,11 @@
-﻿namespace Daas.Domain.Entities;
+﻿using System.Collections;
+
+namespace Daas.Domain.Entities;
 
 public class ResultModel
 {
-
-    public string columnValue  { get; set; }
-    public string fieldValue { get; set; }
+    public ArrayList data;
+    //public string fieldName  { get; set; }
+    //public string fieldValue { get; set; }
     
 }


### PR DESCRIPTION
Implemented a model controller capable to generate int type of data for the request. Basically the controller is able to generate the actaul rquired response model but only with int type of data. Data generation part will be handled in another branch.
**This pull request ensures:**

1. Correct response model is generated for any type of request model (limitation request model should have a single level of objects)
2. The api returns the any number of rows dynamically as selected by user.

So planning to merge this branch and start with simple data generation for other primitive data types in the branch feature/DataGeneration.